### PR TITLE
Fix timezone and optional tqdm

### DIFF
--- a/_org/_posts/2023-12-12-orgmode_blog.org
+++ b/_org/_posts/2023-12-12-orgmode_blog.org
@@ -76,7 +76,7 @@ You can use this script to generate the file sitemap.xml
       " Generate sitemap.xml"
       root = ET.Element('urlset')
       root.attrib['xmlns'] = 'http://www.sitemaps.org/schemas/sitemap/0.9'
-      timezone = pytz.timezone('Asia/Shanghai')
+      timezone = ZoneInfo('Asia/Shanghai')
       for f in os.listdir("."):
 	  if not f.endswith(".html"):
 	      continue
@@ -84,7 +84,9 @@ You can use this script to generate the file sitemap.xml
 	  loc = ET.SubElement(url, "loc")
 	  loc.text = f'https://www.chanmo.me/{f}'
 	  lastmod = ET.SubElement(url, "lastmod")
-	  lastmod.text = timezone.localize(datetime.datetime.fromtimestamp(os.path.getmtime(f))).isoformat(timespec='seconds')
+          lastmod.text = datetime.datetime.fromtimestamp(
+              os.path.getmtime(f), tz=timezone
+          ).isoformat(timespec='seconds')
 
       with open('sitemap.xml', 'wb') as f:
 	  f.write(b'<?xml version="1.0" encoding="utf-8"?>\n')

--- a/_posts/2023-12-12-orgmode_blog.md
+++ b/_posts/2023-12-12-orgmode_blog.md
@@ -77,7 +77,7 @@ def generate_sitemap():
     " Generate sitemap.xml"
     root = ET.Element('urlset')
     root.attrib['xmlns'] = 'http://www.sitemaps.org/schemas/sitemap/0.9'
-    timezone = pytz.timezone('Asia/Shanghai')
+    timezone = ZoneInfo('Asia/Shanghai')
     for f in os.listdir("."):
     if not f.endswith(".html"):
         continue
@@ -85,7 +85,9 @@ def generate_sitemap():
     loc = ET.SubElement(url, "loc")
     loc.text = f'https://www.chanmo.me/{f}'
     lastmod = ET.SubElement(url, "lastmod")
-    lastmod.text = timezone.localize(datetime.datetime.fromtimestamp(os.path.getmtime(f))).isoformat(timespec='seconds')
+    lastmod.text = datetime.datetime.fromtimestamp(
+        os.path.getmtime(f), tz=timezone
+    ).isoformat(timespec='seconds')
 
     with open('sitemap.xml', 'wb') as f:
     f.write(b'<?xml version="1.0" encoding="utf-8"?>\n')

--- a/cli.py
+++ b/cli.py
@@ -3,11 +3,15 @@ import re
 import datetime
 from pathlib import Path
 import subprocess as sp
-import pytz
+from zoneinfo import ZoneInfo
 import xml.etree.ElementTree as ET
 import click
 import shutil
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:  # pragma: no cover - optional dependency
+    def tqdm(iterable):
+        return iterable
 
 
 @click.group
@@ -64,7 +68,7 @@ def generate_sitemap():
     " Generate sitemap.xml"
     root = ET.Element('urlset')
     root.attrib['xmlns'] = 'http://www.sitemaps.org/schemas/sitemap/0.9'
-    timezone = pytz.timezone('Asia/Shanghai')
+    timezone = ZoneInfo('Asia/Shanghai')
     for f in os.listdir("."):
         if not f.endswith(".html"):
             continue
@@ -72,7 +76,9 @@ def generate_sitemap():
         loc = ET.SubElement(url, "loc")
         loc.text = f'https://www.chanmo.me/{f}'
         lastmod = ET.SubElement(url, "lastmod")
-        lastmod.text = timezone.localize(datetime.datetime.fromtimestamp(os.path.getmtime(f))).isoformat(timespec='seconds')
+        lastmod.text = datetime.datetime.fromtimestamp(
+            os.path.getmtime(f), tz=timezone
+        ).isoformat(timespec='seconds')
 
     with open('sitemap.xml', 'wb') as f:
         f.write(b'<?xml version="1.0" encoding="utf-8"?>\n')

--- a/docs/2023/12/12/orgmode_blog.html
+++ b/docs/2023/12/12/orgmode_blog.html
@@ -119,7 +119,7 @@ def generate_sitemap():
     " Generate sitemap.xml"
     root = ET.Element('urlset')
     root.attrib['xmlns'] = 'http://www.sitemaps.org/schemas/sitemap/0.9'
-    timezone = pytz.timezone('Asia/Shanghai')
+    timezone = ZoneInfo('Asia/Shanghai')
     for f in os.listdir("."):
     if not f.endswith(".html"):
         continue
@@ -127,7 +127,9 @@ def generate_sitemap():
     loc = ET.SubElement(url, "loc")
     loc.text = f'https://www.chanmo.me/{f}'
     lastmod = ET.SubElement(url, "lastmod")
-    lastmod.text = timezone.localize(datetime.datetime.fromtimestamp(os.path.getmtime(f))).isoformat(timespec='seconds')
+    lastmod.text = datetime.datetime.fromtimestamp(
+        os.path.getmtime(f), tz=timezone
+    ).isoformat(timespec='seconds')
 
     with open('sitemap.xml', 'wb') as f:
     f.write(b'&lt;?xml version="1.0" encoding="utf-8"?&gt;\n')


### PR DESCRIPTION
## Summary
- handle missing tqdm dependency gracefully
- use Python's zoneinfo instead of pytz in cli script
- update blog post snippets to match new ZoneInfo usage

## Testing
- `python3 -m py_compile cli.py`
- `python3 cli.py --help`
- `python3 cli.py generate-sitemap --help`


------
https://chatgpt.com/codex/tasks/task_e_683fc302be188322857175fa1bc0a383